### PR TITLE
Update plugin to work with WP 4.3

### DIFF
--- a/lib/tribe-widget-factory/Tribe_WP_Widget_Factory.php
+++ b/lib/tribe-widget-factory/Tribe_WP_Widget_Factory.php
@@ -68,9 +68,5 @@ class Tribe_WP_Widget_Factory extends WP_Widget_Factory {
 	final public function __sleep() {
 		trigger_error( "No serialization allowed!", E_USER_ERROR );
 	}
-
-	protected function __construct() {
-		parent::__construct();
-	}
-
+	
 }


### PR DESCRIPTION
Remove unnecessary protected __construct() method on widget. This PR fixes a fatal error with this plugin on wp 4.3.

Internal reference: https://central.tri.be/issues/38820
